### PR TITLE
Support hyphens in reference names

### DIFF
--- a/src/Grammar.php
+++ b/src/Grammar.php
@@ -19,7 +19,7 @@ use function str_replace;
 
 final readonly class Grammar implements GrammarInterface
 {
-    public const string REFERENCE_REGULAR_EXPRESSION = '#\(\?&(\w+)\)#';
+    public const string REFERENCE_REGULAR_EXPRESSION = '#\(\?&([\w-]+)\)#';
 
     /**
      * eg. [

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -154,6 +154,18 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
                     Token::new('T_PUNCTUATION', ')', 1, 15, []),
                 ],
             ],
+
+            'support hyphens in reference names' => [
+                [
+                    'second-one' => '(?&first-one)(?&hyphen)(?&first-one)',
+                    'hyphen' => '\-',
+                    'digit' => '\d',
+                    'first-one' => '(?&digit)+',
+                ],
+                '#(?|(?:(?:(?:\d)+)(?:\-)(?:(?:\d)+))(*MARK:second-one)|(?:\-)(*MARK:hyphen)|(?:\d)(*MARK:digit)|(?:(?:\d)+)(*MARK:first-one))#Au',
+                '123-456',
+                [Token::new('second-one', '123-456', 1, 7, [])],
+            ],
         ];
     }
 }


### PR DESCRIPTION
supports `(?&T_NAME)` and `(?&token-name)` reference names.